### PR TITLE
fix(vscode-js-debug): add default version

### DIFF
--- a/packages/github/microsoft/vscode-js-debug/nvpm.yaml
+++ b/packages/github/microsoft/vscode-js-debug/nvpm.yaml
@@ -12,6 +12,7 @@ categories:
   - DAP
 source:
   id: github:microsoft/vscode-js-debug
+  default_version: v1.117.0
   asset:
     file: js-debug-dap-{{version}}.tar.gz
   bin: node:js-debug/src/dapDebugServer.js


### PR DESCRIPTION
user @dlvhdr kindly reported that the registry and cli prefer v2023.6.817 otherwise.

Without looking at the code again, this is intentional, because 2023 is more than 1 (v1.117.0 is the "latest" version).

Since releases are a github feature and not a git feature and author dates shouldn't be trusted, we can't reliably determine that 2023 is a year, because it could be that some package really uses this as a version number. So we have add the default_version to help the users out here.